### PR TITLE
Simplify auto commit on push

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - master
+    # Ignore changes in folders with generated contents or documentation
+    paths-ignore: 
+      - 'coverage/**'
+      - 'devdist/**'
+      - 'dist/**'
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.txt'
+      - 'LICENSE'
   pull_request:
     branches:
       - master
@@ -16,29 +25,6 @@ jobs:
       CI_COMMIT_AUTHOR: ${{ github.event.repository.name }} Continuous Integration
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
-
-    - name: Set the environment variable "commit-message"
-      run: echo "commit-message=$(git log -1 --pretty=format:"%s")" >> $GITHUB_ENV
-    - name: Display environment variable "commit-message"
-      run: echo "commit-message=${{ env.commit-message }}"
-
-    - name: Set environment variable "commit-author"
-      run: echo "commit-author=$(git log -1 --pretty=format:'%an')" >> $GITHUB_ENV
-    - name: Display environment variable "commit-author"
-      run: echo "commit-author=${{ env.commit-author }}"
-
-    - name: Set environment variable "is-auto-commit"
-      if: env.commit-message == env.CI_COMMIT_MESSAGE && env.commit-author == env.CI_COMMIT_AUTHOR
-      run: echo "is-auto-commit=true" >> $GITHUB_ENV
-    - name: Display environment variable "is-auto-commit"
-      run: echo "is-auto-commit=${{ env.is-auto-commit }}"
-    - name: Info message on CI auto commit 
-      if: env.is-auto-commit
-      run: echo "Continuous Integration Auto Commit - The following steps will be skipped"
-
     - uses: actions/setup-node@v2
       if: env.is-auto-commit == false
       with:
@@ -83,6 +69,14 @@ jobs:
         retention-days: 31
         if-no-files-found: error
     
+    - name: Display github context variable "github.event.commits[0]"
+      run: echo "${{ toJson(github.event.commits[0]) }}" 
+    - name: Set environment variable "is-auto-commit"
+      if: github.event.commits[0].message == env.CI_COMMIT_MESSAGE && github.event.commits[0].author == env.CI_COMMIT_AUTHOR
+      run: echo "is-auto-commit=true" >> $GITHUB_ENV
+    - name: Display environment variable "is-auto-commit"
+      run: echo "is-auto-commit=${{ env.is-auto-commit }}"
+
     - name: Display event name 
       if: env.is-auto-commit == false
       run: echo "github.event_name=${{ github.event_name }}"


### PR DESCRIPTION
Simplify workflow configuration for the auto commit of the build artifacts on push introduced with issue #44.

Since the commit message and author are only needed for the push event, it is not neccessary any more to determine them using git log because `github.event.commits[0]` can be used for push events. 

This leads to a simplified checkout, since the "ref" was only neccessary for git log. 

`paths-ignore` can now be used to skip the pipeline run on the auto commit, since it only affects folders with generated content. This wound't be possible within a pull request, since a skipped workflow runs on the latest commit lead to "some checks haven’t completed yet".

Detecting `env.is-auto-commit` could then also be skipped, but it makes sense to at least leave it to be shure that there is no endless loop when the auto commit someday contains files that aren't covered by the `paths-ignore` definition.