### PR TITLE
Add CHANGELOG.md regeneration to continuous integration pipeline

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -26,6 +26,8 @@ jobs:
     - uses: actions/checkout@v3
       with: 
         token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
+    - name: Get GIT tags for auto-changelog generation (startingVersion config option)
+      run: git fetch --tags origin
 
     # Build
     - uses: actions/setup-node@v3
@@ -49,6 +51,13 @@ jobs:
       with:
         name: documentation
         path: docs
+        retention-days: 14
+        if-no-files-found: error
+    - name: Archive CHANGELOG.md
+      uses: actions/upload-artifact@v3
+      with:
+        name: changelog
+        path: CHANGELOG.md
         retention-days: 14
         if-no-files-found: error
     - name: Archive build artifacts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-restructor",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Transforms parsed JSON objects into a uniform data structure",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "export NODE_OPTIONS=--no-experimental-fetch;parcel build ./src/js/*.js",
     "changelog": "auto-changelog",
     "changelog-debug": "auto-changelog --template json --output changelog-data.json",
-    "package": "npm run lint && npm run coverage && npm run coverage-badge && npm run doc && npm run devbuild && npm run build && npm run merger"
+    "package": "npm run lint && npm run coverage && npm run coverage-badge && npm run doc && npm run changelog && npm run devbuild && npm run build && npm run merger"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Changes

- [Add changelog generation to continuous integration](https://github.com/JohT/data-restructor-js/pull/142/commits/7d7a3938dae0d2162dfd4f2fbc1cece6e093c149)